### PR TITLE
Fixes "possible misuse of comma operator" compiler warnings

### DIFF
--- a/ufs/ufsd/src/apfs/apfsencryption.cpp
+++ b/ufs/ufsd/src/apfs/apfsencryption.cpp
@@ -434,9 +434,9 @@ static int GetDerivedKey(
     {
       CHECK_CALL_LOG(Cf->Hmac(I_CIPHER_SHA256, Pass, PassSize, mac, sizeof(mac), mac), Log);
       // due to hLen % 8 == 0
-      *k       ^= *m,
-      *(k + 1) ^= *(m + 1),
-      *(k + 2) ^= *(m + 2),
+      *k       ^= *m;
+      *(k + 1) ^= *(m + 1);
+      *(k + 2) ^= *(m + 2);
       *(k + 3) ^= *(m + 3);
     }
 

--- a/ufs/ufsd/src/apfs/apfssuper.cpp
+++ b/ufs/ufsd/src/apfs/apfssuper.cpp
@@ -594,7 +594,7 @@ UINT64 CApfsSuperBlock::CreateFSum(
     IN size_t Size
     )
 {
-  register unsigned int* p = reinterpret_cast<unsigned int*>(pData);
+  unsigned int* p = reinterpret_cast<unsigned int*>(pData);
   Size /= 4;
 
   volatile UINT64 sum1 = 0;


### PR DESCRIPTION
CompileC /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Objects-normal/arm64/apfsencryption.o /Users/richard/Tresors/Xcode/Disk\ Decipher/Paragon\ APFS\ SDK\ CE/ufs/ufsd/src/apfs/apfsencryption.cpp normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Paragon APFS SDK CE' from project 'Disk Decipher')
    cd /Users/richard/Tresors/Xcode/Disk\ Decipher
    export LANG\=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -target arm64-apple-ios11.3 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -std\=gnu++14 -stdlib\=libc++ -fmodules -gmodules -fmodules-cache-path\=/Users/richard/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -fmodules-prune-interval\=86400 -fmodules-prune-after\=345600 -fbuild-session-file\=/Users/richard/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror\=non-modular-include-in-framework-module -fmodule-name\=Paragon_APFS_SDK_CE -fapplication-extension -Wno-trigraphs -fpascal-strings -O0 -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror\=return-type -Wdocumentation -Wunreachable-code -Wquoted-include-in-framework-header -Werror\=deprecated-objc-isa-usage -Werror\=objc-root-class -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wno-float-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -DUFSD_APFS_RO -DUFSD_USE_STATIC_TRACE -DDEBUG\=1 -DDEBUG\=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.3.sdk -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -fvisibility-inlines-hidden -Wno-sign-conversion -Winfinite-recursion -Wmove -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wrange-loop-analysis -Wno-semicolon-before-method-body -Wunguarded-availability -fembed-bitcode-marker -index-store-path /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Index/DataStore -iquote /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Paragon_APFS_SDK_CE-generated-files.hmap -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Paragon_APFS_SDK_CE-own-target-headers.hmap -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Paragon_APFS_SDK_CE-all-non-framework-target-headers.hmap -ivfsoverlay /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/all-product-headers.yaml -iquote /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Paragon_APFS_SDK_CE-project-headers.hmap -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Products/Debug-iphoneos/include -I/Users/richard/Tresors/Xcode/Disk\ Decipher/Paragon\ APFS\ SDK\ CE/ufs/api/include -I/Users/richard/Tresors/Xcode/Disk\ Decipher/Paragon\ APFS\ SDK\ CE/ufs/ufsd/include -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/DerivedSources-normal/arm64 -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/DerivedSources/arm64 -I/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/DerivedSources -F/Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Products/Debug-iphoneos -MMD -MT dependencies -MF /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Objects-normal/arm64/apfsencryption.d --serialize-diagnostics /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Objects-normal/arm64/apfsencryption.dia -c /Users/richard/Tresors/Xcode/Disk\ Decipher/Paragon\ APFS\ SDK\ CE/ufs/ufsd/src/apfs/apfsencryption.cpp -o /Users/richard/Library/Developer/Xcode/DerivedData/Disk_Decipher-gpzneyleymjxsbhesubpgquqbgyi/Build/Intermediates.noindex/Disk\ Decipher.build/Debug-iphoneos/Paragon\ APFS\ SDK\ CE.build/Objects-normal/arm64/apfsencryption.o

/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:437:21: warning: possible misuse of comma operator here [-Wcomma]
      *k       ^= *m,
                    ^
/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:437:7: note: cast expression to void to silence warning
      *k       ^= *m,
      ^~~~~~~~~~~~~~
      static_cast<void>( )
/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:438:27: warning: possible misuse of comma operator here [-Wcomma]
      *(k + 1) ^= *(m + 1),
                          ^
/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:438:7: note: cast expression to void to silence warning
      *(k + 1) ^= *(m + 1),
      ^~~~~~~~~~~~~~~~~~~~
      static_cast<void>(  )
/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:439:27: warning: possible misuse of comma operator here [-Wcomma]
      *(k + 2) ^= *(m + 2),
                          ^
/Users/richard/Tresors/Xcode/Disk Decipher/Paragon APFS SDK CE/ufs/ufsd/src/apfs/apfsencryption.cpp:439:7: note: cast expression to void to silence warning
      *(k + 2) ^= *(m + 2),
      ^~~~~~~~~~~~~~~~~~~~
      static_cast<void>(  )
3 warnings generated.