### PR TITLE
Implemented IOCTL_GET_APFS_INFO ioctl

### DIFF
--- a/ufs/ufsd/src/apfs/apfs.h
+++ b/ufs/ufsd/src/apfs/apfs.h
@@ -126,13 +126,13 @@ public:
   // Find cluster with the last checkpoint superblock
   int FindCSBBlock(const apfs_sb* pMSB, UINT64& Block) const;
 
+  // Handler for IOCTL_GET_APFS_INFO
+  virtual int OnGetApfsInfo();
+
 #ifndef UFSD_APFS_RO
   //=================================================================
   //          APFS I/O handlers
   //=================================================================
-
-  // Handler for IOCTL_GET_APFS_INFO
-  virtual int OnGetApfsInfo();
 
   // Handler for IOCTL_GET_RETRIEVAL_POINTERS2
   virtual int OnGetRetrievalPointers();

--- a/ufs/ufsd/src/unixfs/unixfs.cpp
+++ b/ufs/ufsd/src/unixfs/unixfs.cpp
@@ -241,15 +241,24 @@ int CUnixFileSystem::SetVolumeInfo(
 }
 
 int CUnixFileSystem::IoControl(
-    IN  size_t      ,
-    IN  const void* ,
-    IN  size_t      ,
-    OUT void*       ,
-    IN  size_t      ,
-    OUT size_t*
+    IN  size_t      FsIoControlCode,
+    IN  const void* InBuffer,
+    IN  size_t      InBufferSize,
+    OUT void*       OutBuffer,
+    IN  size_t      OutBufferSize,
+    OUT size_t*     BytesReturned
     )
 {
-  return ERR_NOTIMPLEMENTED;
+    m_IO.InBuffer = InBuffer;
+    m_IO.InBufferSize = InBufferSize;
+    m_IO.OutBuffer = OutBuffer;
+    m_IO.OutBufferSize = OutBufferSize;
+    m_IO.BytesReturned = BytesReturned;
+    switch (FsIoControlCode) {
+        case IOCTL_GET_APFS_INFO:
+            return OnGetApfsInfo();
+    }
+    return ERR_NOTIMPLEMENTED;
 }
 
 int CUnixFileSystem::OnGetRetrievalPointers() { return ERR_NOTIMPLEMENTED; }


### PR DESCRIPTION
I needed some of the fields provided by the UFSD_VOLUME_APFS_INFO for a project, but the IOCTL_GET_APFS_INFO ioctl is not available in the current release, although it is readonly.

This pull request adds the IOCTL_GET_APFS_INFO ioctl.